### PR TITLE
Manage tasks by statuses

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -13,7 +13,7 @@
           "styleext": "scss"
         }
       },
-      "targets": {
+      "architect": {
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {

--- a/src/main/webapp/app/app.component.html
+++ b/src/main/webapp/app/app.component.html
@@ -6,7 +6,7 @@
       </div>
       <tiny-task-form
         (created)="created()"
-        (clearDoneTasks)="clearDoneTasks()"
+        (clearDoneTasks)="clearFinishedTasks()"
       ></tiny-task-form>
     </div>
   </mat-toolbar>

--- a/src/main/webapp/app/app.component.html
+++ b/src/main/webapp/app/app.component.html
@@ -4,7 +4,10 @@
       <div class="logo">
         <img src="assets/images/logos/coyo/logo-coyo-inversed-nav-hd.png" alt="COYO">
       </div>
-      <tiny-task-form (created)="created()"></tiny-task-form>
+      <tiny-task-form
+        (created)="created()"
+        (clearDoneTasks)="clearDoneTasks()"
+      ></tiny-task-form>
     </div>
   </mat-toolbar>
   <section class="content">

--- a/src/main/webapp/app/app.component.html
+++ b/src/main/webapp/app/app.component.html
@@ -4,12 +4,16 @@
       <div class="logo">
         <img src="assets/images/logos/coyo/logo-coyo-inversed-nav-hd.png" alt="COYO">
       </div>
-      <tiny-task-form (created)="created($event)"></tiny-task-form>
+      <tiny-task-form (created)="created()"></tiny-task-form>
     </div>
   </mat-toolbar>
   <section class="content">
     <div class="wrapper">
-      <tiny-task-list [tasks]="tasks$ | async" (deleted)="deleted($event)"></tiny-task-list>
+      <tiny-task-list
+        [tasks]="tasks$ | async"
+        (deleted)="deleted()"
+        (statusChanged)="statusChanged()"
+      ></tiny-task-list>
     </div>
   </section>
 </div>

--- a/src/main/webapp/app/app.component.spec.ts
+++ b/src/main/webapp/app/app.component.spec.ts
@@ -68,4 +68,30 @@ describe('AppComponent', () => {
     expect(component.tasks$).toEqual(tasks$);
     expect(taskService.getAll).toHaveBeenCalled();
   });
+
+  it('should reload the tasks after finished tasks were cleared', () => {
+    // given
+    const tasks$ = of([]);
+    taskService.getAll.and.returnValue(tasks$);
+
+    // when
+    component.clearFinishedTasks();
+
+    // then
+    expect(component.tasks$).toEqual(tasks$);
+    expect(taskService.getAll).toHaveBeenCalled();
+  });
+
+  it('should reload the tasks after status was changed', () => {
+    // given
+    const tasks$ = of([]);
+    taskService.getAll.and.returnValue(tasks$);
+
+    // when
+    component.statusChanged();
+
+    // then
+    expect(component.tasks$).toEqual(tasks$);
+    expect(taskService.getAll).toHaveBeenCalled();
+  });
 });

--- a/src/main/webapp/app/app.component.ts
+++ b/src/main/webapp/app/app.component.ts
@@ -34,15 +34,6 @@ export class AppComponent implements OnInit {
   }
 
   clearFinishedTasks(): void {
-    this.tasks$.pipe(
-      take(1),
-      map((tasks: Task[]) => tasks
-        .filter((task: Task) => FINISHED_TASK_STATUSES.includes(task.status))
-        .map(({id}: Task) => id)
-      ),
-      mergeMap((taskIds: string[]) => this.taskService.deleteAll(taskIds))
-    ).subscribe(() => {
-      this.tasks$ = this.taskService.getAll();
-    });
+    this.tasks$ = this.taskService.getAll();
   }
 }

--- a/src/main/webapp/app/app.component.ts
+++ b/src/main/webapp/app/app.component.ts
@@ -27,4 +27,8 @@ export class AppComponent implements OnInit {
   deleted(): void {
     this.tasks$ = this.taskService.getAll();
   }
+
+  statusChanged(): void {
+    this.tasks$ = this.taskService.getAll();
+  }
 }

--- a/src/main/webapp/app/app.component.ts
+++ b/src/main/webapp/app/app.component.ts
@@ -1,8 +1,9 @@
-import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
-import { Observable } from 'rxjs';
+import {ChangeDetectionStrategy, Component, Inject, OnInit} from '@angular/core';
+import {forkJoin, Observable} from 'rxjs';
 
-import { Task } from './tasks/task';
-import { TaskService } from './tasks/task.service';
+import {Task, TaskStatus} from './tasks/task';
+import {TaskService} from './tasks/task.service';
+import {map, mergeMap, take} from "rxjs/operators";
 
 @Component({
   selector: 'tiny-root',
@@ -30,5 +31,15 @@ export class AppComponent implements OnInit {
 
   statusChanged(): void {
     this.tasks$ = this.taskService.getAll();
+  }
+
+  clearDoneTasks(): void {
+    this.tasks$.pipe(
+      take(1),
+      map((tasks: Task[]) => tasks.filter((task: Task) => task.status === TaskStatus.Done)),
+      mergeMap((tasks: Task[]) => forkJoin(...tasks.map((task: Task) => this.taskService.delete(task.id))))
+    ).subscribe(() => {
+      this.tasks$ = this.taskService.getAll();
+    });
   }
 }

--- a/src/main/webapp/app/app.component.ts
+++ b/src/main/webapp/app/app.component.ts
@@ -36,8 +36,11 @@ export class AppComponent implements OnInit {
   clearDoneTasks(): void {
     this.tasks$.pipe(
       take(1),
-      map((tasks: Task[]) => tasks.filter((task: Task) => task.status === TaskStatus.Done)),
-      mergeMap((tasks: Task[]) => forkJoin(...tasks.map((task: Task) => this.taskService.delete(task.id))))
+      map((tasks: Task[]) => tasks
+        .filter((task: Task) => task.status === TaskStatus.Done)
+        .map(({id}: Task) => id)
+      ),
+      mergeMap((taskIds: string[]) => this.taskService.deleteAll(taskIds))
     ).subscribe(() => {
       this.tasks$ = this.taskService.getAll();
     });

--- a/src/main/webapp/app/app.component.ts
+++ b/src/main/webapp/app/app.component.ts
@@ -1,9 +1,9 @@
 import {ChangeDetectionStrategy, Component, Inject, OnInit} from '@angular/core';
-import {forkJoin, Observable} from 'rxjs';
+import {Observable} from 'rxjs';
 
-import {Task, TaskStatus} from './tasks/task';
+import {FINISHED_TASK_STATUSES, Task} from './tasks/task';
 import {TaskService} from './tasks/task.service';
-import {map, mergeMap, take} from "rxjs/operators";
+import {map, mergeMap, take} from 'rxjs/operators';
 
 @Component({
   selector: 'tiny-root',
@@ -33,11 +33,11 @@ export class AppComponent implements OnInit {
     this.tasks$ = this.taskService.getAll();
   }
 
-  clearDoneTasks(): void {
+  clearFinishedTasks(): void {
     this.tasks$.pipe(
       take(1),
       map((tasks: Task[]) => tasks
-        .filter((task: Task) => task.status === TaskStatus.Done)
+        .filter((task: Task) => FINISHED_TASK_STATUSES.includes(task.status))
         .map(({id}: Task) => id)
       ),
       mergeMap((taskIds: string[]) => this.taskService.deleteAll(taskIds))

--- a/src/main/webapp/app/app.component.ts
+++ b/src/main/webapp/app/app.component.ts
@@ -1,9 +1,8 @@
 import {ChangeDetectionStrategy, Component, Inject, OnInit} from '@angular/core';
 import {Observable} from 'rxjs';
 
-import {FINISHED_TASK_STATUSES, Task} from './tasks/task';
+import {Task} from './tasks/task';
 import {TaskService} from './tasks/task.service';
-import {map, mergeMap, take} from 'rxjs/operators';
 
 @Component({
   selector: 'tiny-root',
@@ -13,7 +12,7 @@ import {map, mergeMap, take} from 'rxjs/operators';
 })
 export class AppComponent implements OnInit {
 
-  tasks$: Observable<Task[]>;
+  tasks$!: Observable<Task[]>;
 
   constructor(@Inject('TaskService') private taskService: TaskService) { }
 

--- a/src/main/webapp/app/shared/shared.module.ts
+++ b/src/main/webapp/app/shared/shared.module.ts
@@ -1,0 +1,12 @@
+import {NgModule} from '@angular/core';
+import {TinyLetDirective} from 'app/shared/tiny-let/tiny-let.directive';
+
+@NgModule({
+  exports: [
+    TinyLetDirective
+  ],
+  declarations: [
+    TinyLetDirective
+  ]
+})
+export class SharedModule { }

--- a/src/main/webapp/app/shared/tiny-let/tiny-let.directive.ts
+++ b/src/main/webapp/app/shared/tiny-let/tiny-let.directive.ts
@@ -1,0 +1,25 @@
+import { Directive, Input, TemplateRef, ViewContainerRef, Inject } from '@angular/core';
+
+export class LetContext<T> {
+  constructor(
+    private readonly dir: TinyLetDirective<T>
+  ) { }
+
+  get tinyLet(): T {
+    return this.dir.tinyLet;
+  }
+}
+
+@Directive({
+  selector: '[tinyLet]'
+})
+export class TinyLetDirective<T> {
+  @Input() tinyLet: T;
+
+  constructor(
+    @Inject(ViewContainerRef) viewContainer: ViewContainerRef,
+    @Inject(TemplateRef) templateRef: TemplateRef<LetContext<T>>
+  ) {
+    viewContainer.createEmbeddedView(templateRef, new LetContext<T>(this));
+  }
+}

--- a/src/main/webapp/app/shared/tiny-let/tiny-let.directive.ts
+++ b/src/main/webapp/app/shared/tiny-let/tiny-let.directive.ts
@@ -2,11 +2,11 @@ import { Directive, Input, TemplateRef, ViewContainerRef, Inject } from '@angula
 
 export class LetContext<T> {
   constructor(
-    private readonly dir: TinyLetDirective<T>
+    private readonly directive: TinyLetDirective<T>
   ) { }
 
-  get tinyLet(): T {
-    return this.dir.tinyLet;
+  get tinyLet(): T | null {
+    return this.directive.tinyLet;
   }
 }
 
@@ -14,7 +14,7 @@ export class LetContext<T> {
   selector: '[tinyLet]'
 })
 export class TinyLetDirective<T> {
-  @Input() tinyLet: T;
+  @Input() tinyLet: T | null = null;
 
   constructor(
     @Inject(ViewContainerRef) viewContainer: ViewContainerRef,

--- a/src/main/webapp/app/tasks/default-task.service.spec.ts
+++ b/src/main/webapp/app/tasks/default-task.service.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { BASE_URL } from 'app/app.tokens';
 
 import { DefaultTaskService } from './default-task.service';
+import {TaskStatus} from "app/tasks/task";
 
 describe('DefaultTaskService', () => {
   let httpTestingController: HttpTestingController;
@@ -57,6 +58,30 @@ describe('DefaultTaskService', () => {
     // then
     const req = httpTestingController.expectOne(request => request.url === 'http://backend.tld/tasks/id123');
     expect(req.request.method).toEqual('DELETE');
+
+    // finally
+    req.flush({});
+  });
+
+  it('should delete a list of tasks', () => {
+    // when
+    taskService.deleteAll(['1', '2', '3']).subscribe();
+
+    // then
+    const req = httpTestingController.expectOne(request => request.urlWithParams === 'http://backend.tld/tasks?id=1&id=2&id=3');
+    expect(req.request.method).toEqual('DELETE');
+
+    // finally
+    req.flush({});
+  });
+
+  it('should set new status for task', () => {
+    // when
+    taskService.setStatus('id123', TaskStatus.Done).subscribe();
+
+    // then
+    const req = httpTestingController.expectOne(request => request.url === 'http://backend.tld/tasks/id123/status');
+    expect(req.request.method).toEqual('PUT');
 
     // finally
     req.flush({});

--- a/src/main/webapp/app/tasks/default-task.service.ts
+++ b/src/main/webapp/app/tasks/default-task.service.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { BASE_URL } from '../app.tokens';
-import { Task } from './task';
+import {Task, TaskStatus} from './task';
 import { TaskService } from './task.service';
 
 @Injectable()
@@ -22,5 +22,9 @@ export class DefaultTaskService implements TaskService {
 
   getAll(): Observable<Task[]> {
     return this.http.get<Task[]>(this.baseUrl + '/tasks');
+  }
+
+  setStatus(id: string, status: TaskStatus): Observable<Task> {
+    return this.http.put<Task>(this.baseUrl + '/tasks/' + id + '/status', { status });
   }
 }

--- a/src/main/webapp/app/tasks/default-task.service.ts
+++ b/src/main/webapp/app/tasks/default-task.service.ts
@@ -16,9 +16,14 @@ export class DefaultTaskService implements TaskService {
     return this.http.post<Task>(this.baseUrl + '/tasks', {name} as Task);
   }
 
-  delete(id: string): Observable<void> {
-    return this.http.delete<void>(this.baseUrl + '/tasks/' + id);
+  delete(id: string): Observable<null> {
+    return this.http.delete<null>(this.baseUrl + '/tasks/' + id);
   }
+
+  deleteAll(ids: string[]): Observable<null> {
+    return this.http.delete<null>(this.baseUrl + '/tasks', {params: {id: ids}});
+  }
+
 
   getAll(): Observable<Task[]> {
     return this.http.get<Task[]>(this.baseUrl + '/tasks');

--- a/src/main/webapp/app/tasks/default-task.service.ts
+++ b/src/main/webapp/app/tasks/default-task.service.ts
@@ -16,13 +16,13 @@ export class DefaultTaskService implements TaskService {
     return this.http.post<Task>(this.baseUrl + '/tasks', {name} as Task);
   }
 
-  delete(id: string): Observable<null> {
-    return this.http.delete<null>(this.baseUrl + '/tasks/' + id);
+  delete(id: string): Observable<void> {
+    return this.http.delete<void>(this.baseUrl + '/tasks/' + id);
   }
 
-  deleteAll(ids: string[]): Observable<null> {
+  deleteAll(ids: string[]): Observable<void> {
     const params = new HttpParams({fromObject: {id: ids}});
-    return this.http.delete<null>(this.baseUrl + '/tasks', {params});
+    return this.http.delete<void>(this.baseUrl + '/tasks', {params});
   }
 
 

--- a/src/main/webapp/app/tasks/default-task.service.ts
+++ b/src/main/webapp/app/tasks/default-task.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import {HttpClient, HttpParams} from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
@@ -21,7 +21,8 @@ export class DefaultTaskService implements TaskService {
   }
 
   deleteAll(ids: string[]): Observable<null> {
-    return this.http.delete<null>(this.baseUrl + '/tasks', {params: {id: ids}});
+    const params = new HttpParams({fromObject: {id: ids}});
+    return this.http.delete<null>(this.baseUrl + '/tasks', {params});
   }
 
 

--- a/src/main/webapp/app/tasks/local-task.service.spec.ts
+++ b/src/main/webapp/app/tasks/local-task.service.spec.ts
@@ -1,13 +1,9 @@
-import { TestBed } from '@angular/core/testing';
-import { LocalTaskService } from 'app/tasks/local-task.service';
-import { Observable } from 'rxjs';
-import { Task } from './task';
+import {TestBed} from '@angular/core/testing';
+import {LocalTaskService} from 'app/tasks/local-task.service';
+import {EMPTY, Observable} from 'rxjs';
+import {Task, TaskStatus} from './task';
 
 describe('LocalTaskService', () => {
-  const id = 'de4f576e-d1b5-488a-8c77-63d4c8726909';
-  const name = 'Doing the do!';
-  const mockTask = `{"id":"${id}","name":"${name}"}`;
-
   let taskService: LocalTaskService;
 
   beforeEach(() => {
@@ -16,40 +12,100 @@ describe('LocalTaskService', () => {
     });
 
     taskService = TestBed.inject(LocalTaskService);
-    spyOn(localStorage, 'getItem').and.callFake(() => `[${mockTask}]`);
-    spyOn(localStorage, 'setItem').and.callFake(() => {});
   });
 
-  it('should be created', () => {
-    expect(taskService).toBeTruthy();
-  });
+  describe('single task in store', () => {
+    beforeEach(() => {
+      spyOn(localStorage, 'getItem').and.callFake(() => `[${mockTask}]`);
+      spyOn(localStorage, 'setItem').and.callFake(() => { });
+    });
 
-  it('should return tasks from local storage', () => {
-    // when
-    const taskList$: Observable<Task[]> = taskService.getAll();
+    const id = 'de4f576e-d1b5-488a-8c77-63d4c8726909';
+    const name = 'Doing the do!';
+    const status = String(TaskStatus.Todo);
+    const mockTask = `{"id":"${id}","name":"${name}","status":"${status}"}`;
+    it('should be created', () => {
+      expect(taskService).toBeTruthy();
+    });
 
-    // then
-    expect(localStorage.getItem).toHaveBeenCalled();
-    taskList$.subscribe(taskList => {
-      expect(taskList.length).toBe(1);
-      expect(taskList[0].name).toEqual(name);
+    it('should return tasks from local storage', () => {
+      // when
+      const taskList$: Observable<Task[]> = taskService.getAll();
+
+      // then
+      expect(localStorage.getItem).toHaveBeenCalled();
+      taskList$.subscribe(taskList => {
+        expect(taskList.length).toBe(1);
+        expect(taskList[0].name).toEqual(name);
+      });
+    });
+
+    it('should write task to local storage', () => {
+      // when
+      taskService.create('Drinking the drink!');
+
+      // then
+      expect(localStorage.setItem).toHaveBeenCalled();
+    });
+
+    it('should delete task from local storage', () => {
+      // when
+      taskService.delete(id);
+
+      // then
+      expect(localStorage.getItem).toHaveBeenCalled();
+      expect(localStorage.setItem).toHaveBeenCalled();
+    });
+
+    it('should set new status for task', () => {
+      // when
+      taskService.setStatus(id, TaskStatus.Done);
+
+      // then
+      expect(localStorage.setItem).toHaveBeenCalledWith('tiny.tasks', JSON.stringify([
+        {id, name, status: TaskStatus.Done}
+      ]));
+    });
+
+    it('should return updated task', () => {
+      // when
+      const result = taskService.setStatus(id, TaskStatus.Done);
+
+      // then
+      const subscription = result.subscribe(value => {
+        expect(value).toEqual({id, name, status: TaskStatus.Done});
+      });
+      subscription.unsubscribe();
+    });
+
+    it('should return completed observable if no task was found to update', () => {
+      // when
+      const result = taskService.setStatus('id123', TaskStatus.Done);
+
+      // then
+      expect(result).toEqual(EMPTY);
     });
   });
+  describe('multiple tasks', () => {
+    beforeEach(() => {
+      spyOn(localStorage, 'getItem').and.callFake(() => JSON.stringify([
+        { id: 'id007', name: 'bang', status: TaskStatus.Todo },
+        { id: 'id123', name: 'say hello', status: TaskStatus.Todo },
+        { id: 'id1234', name: 'say goodbye', status: TaskStatus.Cancelled },
+        { id: 'id000', name: 'todo not todo', status: TaskStatus.Todo },
+      ]));
+      spyOn(localStorage, 'setItem').and.callFake(() => { });
+    });
 
-  it('should write task to local storage', () => {
-    // when
-    taskService.create('Drinking the drink!');
+    it('should delete a list of tasks from local storage', () => {
+      // when
+      taskService.deleteAll(['id123', 'id1234']);
 
-    // then
-    expect(localStorage.setItem).toHaveBeenCalled();
-  });
-
-  it('should delete task from local storage', () => {
-    // when
-    taskService.delete(id);
-
-    // then
-    expect(localStorage.getItem).toHaveBeenCalled();
-    expect(localStorage.setItem).toHaveBeenCalled();
+      // then
+      expect(localStorage.setItem).toHaveBeenCalledWith('tiny.tasks', JSON.stringify([
+        {id: 'id007', name: 'bang', status: TaskStatus.Todo},
+        {id: 'id000', name: 'todo not todo', status: TaskStatus.Todo}
+      ]));
+    });
   });
 });

--- a/src/main/webapp/app/tasks/local-task.service.ts
+++ b/src/main/webapp/app/tasks/local-task.service.ts
@@ -40,7 +40,7 @@ export class LocalTaskService implements TaskService {
   }
 
 
-  setStatus(id: string, status: TaskStatus): Observable<Task> {
+  setStatus(id: string, status: TaskStatus): Observable<Task | never> {
     const tasks = this.readTasks();
     const task = tasks.find(({id: taskId}: Task) => taskId === id);
     if (!task) { return EMPTY; }

--- a/src/main/webapp/app/tasks/local-task.service.ts
+++ b/src/main/webapp/app/tasks/local-task.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import {EMPTY, Observable, of} from 'rxjs';
 import { v4 as uuid } from 'uuid';
 
-import { Task } from './task';
+import {Task, TaskStatus} from './task';
 import { TaskService } from './task.service';
 
 @Injectable()
@@ -16,7 +16,7 @@ export class LocalTaskService implements TaskService {
 
   create(name: string): Observable<Task> {
     const tasks = this.readTasks();
-    const task = {id: uuid(), name};
+    const task = {id: uuid(), name, status: TaskStatus.Active};
     tasks.push(task);
     this.writeTasks(tasks);
     return of(task);
@@ -30,6 +30,16 @@ export class LocalTaskService implements TaskService {
       this.writeTasks(tasks);
     }
     return of(null);
+  }
+
+  setStatus(id: string, status: TaskStatus): Observable<Task> {
+    const tasks = this.readTasks();
+    const task = tasks.find(({id: taskId}: Task) => taskId === id);
+    if (!task) { return EMPTY; }
+
+    task.status = status;
+    this.writeTasks(tasks);
+    return of(task);
   }
 
   private readTasks(): Task[] {

--- a/src/main/webapp/app/tasks/local-task.service.ts
+++ b/src/main/webapp/app/tasks/local-task.service.ts
@@ -22,7 +22,7 @@ export class LocalTaskService implements TaskService {
     return of(task);
   }
 
-  delete(id: string): Observable<void> {
+  delete(id: string): Observable<null> {
     const tasks = this.readTasks();
     const index = tasks.findIndex(task => task.id === id);
     if (index !== -1) {
@@ -31,6 +31,14 @@ export class LocalTaskService implements TaskService {
     }
     return of(null);
   }
+
+  deleteAll(ids: string[]): Observable<null> {
+    const tasks = this.readTasks();
+    const restTasks = tasks.filter((task: Task) => !ids.includes(task.id));
+    this.writeTasks(restTasks);
+    return of(null);
+  }
+
 
   setStatus(id: string, status: TaskStatus): Observable<Task> {
     const tasks = this.readTasks();

--- a/src/main/webapp/app/tasks/local-task.service.ts
+++ b/src/main/webapp/app/tasks/local-task.service.ts
@@ -16,7 +16,7 @@ export class LocalTaskService implements TaskService {
 
   create(name: string): Observable<Task> {
     const tasks = this.readTasks();
-    const task = {id: uuid(), name, status: TaskStatus.Active};
+    const task = {id: uuid(), name, status: TaskStatus.Todo};
     tasks.push(task);
     this.writeTasks(tasks);
     return of(task);

--- a/src/main/webapp/app/tasks/local-task.service.ts
+++ b/src/main/webapp/app/tasks/local-task.service.ts
@@ -22,21 +22,21 @@ export class LocalTaskService implements TaskService {
     return of(task);
   }
 
-  delete(id: string): Observable<null> {
+  delete(id: string): Observable<void> {
     const tasks = this.readTasks();
     const index = tasks.findIndex(task => task.id === id);
     if (index !== -1) {
       tasks.splice(index, 1);
       this.writeTasks(tasks);
     }
-    return of(null);
+    return of(undefined);
   }
 
-  deleteAll(ids: string[]): Observable<null> {
+  deleteAll(ids: string[]): Observable<void> {
     const tasks = this.readTasks();
     const restTasks = tasks.filter((task: Task) => !ids.includes(task.id));
     this.writeTasks(restTasks);
-    return of(null);
+    return of(undefined);
   }
 
 

--- a/src/main/webapp/app/tasks/task-form/task-form.component.html
+++ b/src/main/webapp/app/tasks/task-form/task-form.component.html
@@ -4,4 +4,4 @@
     <mat-icon matSuffix aria-label="Add task" aria-role="button" (click)="onSubmit()">send</mat-icon>
   </mat-form-field>
 </form>
-<button mat-raised-button (click)="clearDoneTasks.emit()">Clear Done Tiny Tasks</button>
+<button mat-raised-button (click)="clearDoneTasks.emit()">Clear Finished Tiny Tasks</button>

--- a/src/main/webapp/app/tasks/task-form/task-form.component.html
+++ b/src/main/webapp/app/tasks/task-form/task-form.component.html
@@ -1,6 +1,7 @@
 <form [formGroup]="taskForm" (ngSubmit)="onSubmit()">
   <mat-form-field>
     <input type="text" formControlName="name" matInput placeholder="Add a new tiny task…" data-cy="task-input">
-    <mat-icon matSuffix aria-label="Add task"(click)="onSubmit()">send</mat-icon>
+    <mat-icon matSuffix aria-label="Add task" aria-role="button" (click)="onSubmit()">send</mat-icon>
   </mat-form-field>
 </form>
+<button mat-raised-button (click)="clearDoneTasks.emit()">Clear Done Tiny Tasks</button>

--- a/src/main/webapp/app/tasks/task-form/task-form.component.html
+++ b/src/main/webapp/app/tasks/task-form/task-form.component.html
@@ -1,4 +1,4 @@
-<form [formGroup]="taskForm" (ngSubmit)="onSubmit()">
+<form [formGroup]="taskForm" (ngSubmit)="onSubmit()" autocomplete="off">
   <mat-form-field>
     <input type="text" formControlName="name" matInput placeholder="Add a new tiny task…" data-cy="task-input">
     <mat-icon matSuffix aria-label="Add task" aria-role="button" (click)="onSubmit()">send</mat-icon>

--- a/src/main/webapp/app/tasks/task-form/task-form.component.html
+++ b/src/main/webapp/app/tasks/task-form/task-form.component.html
@@ -4,4 +4,4 @@
     <mat-icon matSuffix aria-label="Add task" aria-role="button" (click)="onSubmit()">send</mat-icon>
   </mat-form-field>
 </form>
-<button mat-raised-button (click)="clearDoneTasks.emit()">Clear Finished Tiny Tasks</button>
+<button mat-raised-button (click)="onClearFinishedTasks()">Clear Finished Tiny Tasks</button>

--- a/src/main/webapp/app/tasks/task-form/task-form.component.ts
+++ b/src/main/webapp/app/tasks/task-form/task-form.component.ts
@@ -1,8 +1,9 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Inject, Output } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 
-import { Task } from '../task';
+import {FINISHED_TASK_STATUSES, Task} from '../task';
 import { TaskService } from '../task.service';
+import {map, mergeMap, take, tap} from "rxjs/operators";
 
 /**
  * A form to create tiny tasks.
@@ -28,6 +29,19 @@ export class TaskFormComponent {
     this.taskService.create(this.taskForm.value.name).subscribe(task => {
       this.created.emit(task);
       this.taskForm.reset();
+    });
+  }
+
+  onClearFinishedTasks(): void {
+    this.taskService.getAll().pipe(
+      take(1),
+      map((tasks: Task[]) => tasks
+        .filter((task: Task) => FINISHED_TASK_STATUSES.includes(task.status))
+        .map(({id}: Task) => id)
+      ),
+      mergeMap((taskIds: string[]) => this.taskService.deleteAll(taskIds))
+    ).subscribe(() => {
+      this.clearDoneTasks.emit();
     });
   }
 }

--- a/src/main/webapp/app/tasks/task-form/task-form.component.ts
+++ b/src/main/webapp/app/tasks/task-form/task-form.component.ts
@@ -15,7 +15,8 @@ import { TaskService } from '../task.service';
 })
 export class TaskFormComponent {
 
-  @Output() created: EventEmitter<Task> = new EventEmitter();
+  @Output() public readonly created: EventEmitter<Task> = new EventEmitter();
+  @Output() public readonly clearDoneTasks: EventEmitter<void> = new EventEmitter();
 
   taskForm: FormGroup = new FormGroup({
     name: new FormControl('', Validators.required)

--- a/src/main/webapp/app/tasks/task-list/sort-tasks.pipe.spec.ts
+++ b/src/main/webapp/app/tasks/task-list/sort-tasks.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { SortTasksPipe } from './sort-tasks.pipe';
+
+describe('SortTasksPipe', () => {
+  it('create an instance', () => {
+    const pipe = new SortTasksPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/main/webapp/app/tasks/task-list/sort-tasks.pipe.spec.ts
+++ b/src/main/webapp/app/tasks/task-list/sort-tasks.pipe.spec.ts
@@ -45,4 +45,17 @@ describe('SortTasksPipe', () => {
     ];
     expect(pipe.transform(tasks, order).slice(0, 2).map(({id}: Task) => id)).toEqual(['4', '2']);
   });
+
+  it('should not mutate passed array', () => {
+    const pipe = new SortTasksPipe();
+    const order = [TaskStatus.Todo, TaskStatus.InProgress];
+    const tasks: Task[] = [
+      { id: '1', name: '1', status: TaskStatus.Todo },
+      { id: '2', name: '2', status: TaskStatus.InProgress },
+      { id: '3', name: '3', status: TaskStatus.Todo },
+    ];
+    const result = pipe.transform(tasks, order);
+    expect(result).not.toBe(tasks);
+    expect(tasks.map(({id}: Task) => id)).toEqual(['1', '2', '3']);
+  });
 });

--- a/src/main/webapp/app/tasks/task-list/sort-tasks.pipe.spec.ts
+++ b/src/main/webapp/app/tasks/task-list/sort-tasks.pipe.spec.ts
@@ -1,8 +1,48 @@
-import { SortTasksPipe } from './sort-tasks.pipe';
+import {DEFAULT_TASK_STATUS_ORDER, SortTasksPipe} from './sort-tasks.pipe';
+import {Task, TaskStatus} from "app/tasks/task";
 
 describe('SortTasksPipe', () => {
   it('create an instance', () => {
     const pipe = new SortTasksPipe();
     expect(pipe).toBeTruthy();
+  });
+
+  it('should use default sorting order with done on the top if no other order provided', () => {
+    const pipe = new SortTasksPipe();
+    const tasks: Task[] = [
+      { id: '1', name: '1', status: TaskStatus.Blocked },
+      { id: '2', name: '2', status: TaskStatus.InProgress },
+      { id: '3', name: '3', status: TaskStatus.Done },
+      { id: '4', name: '4', status: TaskStatus.Todo },
+      { id: '5', name: '5', status: TaskStatus.Cancelled },
+    ];
+    const result = pipe.transform(tasks).map(({status}: Task) => status);
+    expect(result).toEqual(DEFAULT_TASK_STATUS_ORDER);
+    expect(result[0]).toBe(TaskStatus.Todo);
+  });
+
+  it('should keep perform stable sort (do not change original order)', () => {
+    const pipe = new SortTasksPipe();
+    const order = [TaskStatus.Todo, TaskStatus.Cancelled, TaskStatus.Blocked];
+    const tasks: Task[] = [
+      { id: '1', name: '1', status: TaskStatus.Cancelled },
+      { id: '2', name: '2', status: TaskStatus.Blocked },
+      { id: '3', name: '3', status: TaskStatus.Blocked },
+      { id: '4', name: '4', status: TaskStatus.Todo }
+    ];
+    expect(pipe.transform(tasks, order).map(({id}: Task) => id)).toEqual(['4', '1', '2', '3']);
+  });
+
+  it('should leave items not described in order at the end of the list', () => {
+    const pipe = new SortTasksPipe();
+    const order = [TaskStatus.Todo, TaskStatus.InProgress];
+    const tasks: Task[] = [
+      { id: '1', name: '1', status: TaskStatus.Blocked },
+      { id: '2', name: '2', status: TaskStatus.InProgress },
+      { id: '3', name: '3', status: TaskStatus.Done },
+      { id: '4', name: '4', status: TaskStatus.Todo },
+      { id: '5', name: '5', status: TaskStatus.Cancelled },
+    ];
+    expect(pipe.transform(tasks, order).slice(0, 2).map(({id}: Task) => id)).toEqual(['4', '2']);
   });
 });

--- a/src/main/webapp/app/tasks/task-list/sort-tasks.pipe.ts
+++ b/src/main/webapp/app/tasks/task-list/sort-tasks.pipe.ts
@@ -1,7 +1,7 @@
 import {Pipe, PipeTransform} from '@angular/core';
 import {Task, TaskStatus} from '../task';
 
-const taskStatusOrder = [
+export const DEFAULT_TASK_STATUS_ORDER = [
   TaskStatus.Todo,
   TaskStatus.InProgress,
   TaskStatus.Blocked,
@@ -14,12 +14,15 @@ const taskStatusOrder = [
 })
 export class SortTasksPipe implements PipeTransform {
 
-  transform(tasks: Task[], order: TaskStatus[] = taskStatusOrder): Task[] {
+  transform(tasks: Task[], order: TaskStatus[] = DEFAULT_TASK_STATUS_ORDER): Task[] {
     return [...tasks].sort((a: Task, b: Task): number => {
       if (a.status === b.status) { return 0; }
+      const aIndex = order.indexOf(a.status);
+      const bIndex = order.indexOf(b.status);
+      if (aIndex < 0) { return 1; }
+      if (bIndex < 0) { return -1; }
 
-      return order.indexOf(a.status) - order.indexOf(b.status);
+      return  aIndex - bIndex;
     });
   }
-
 }

--- a/src/main/webapp/app/tasks/task-list/sort-tasks.pipe.ts
+++ b/src/main/webapp/app/tasks/task-list/sort-tasks.pipe.ts
@@ -1,16 +1,24 @@
 import {Pipe, PipeTransform} from '@angular/core';
 import {Task, TaskStatus} from '../task';
 
+const taskStatusOrder = [
+  TaskStatus.Todo,
+  TaskStatus.InProgress,
+  TaskStatus.Blocked,
+  TaskStatus.Done,
+  TaskStatus.Cancelled
+];
+
 @Pipe({
   name: 'sortTasks'
 })
 export class SortTasksPipe implements PipeTransform {
 
-  transform(tasks: Task[]): Task[] {
+  transform(tasks: Task[], order: TaskStatus[] = taskStatusOrder): Task[] {
     return [...tasks].sort((a: Task, b: Task): number => {
       if (a.status === b.status) { return 0; }
 
-      return a.status === TaskStatus.Active ? -1 : 1;
+      return order.indexOf(a.status) - order.indexOf(b.status);
     });
   }
 

--- a/src/main/webapp/app/tasks/task-list/sort-tasks.pipe.ts
+++ b/src/main/webapp/app/tasks/task-list/sort-tasks.pipe.ts
@@ -1,0 +1,17 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {Task, TaskStatus} from '../task';
+
+@Pipe({
+  name: 'sortTasks'
+})
+export class SortTasksPipe implements PipeTransform {
+
+  transform(tasks: Task[]): Task[] {
+    return [...tasks].sort((a: Task, b: Task): number => {
+      if (a.status === b.status) { return 0; }
+
+      return a.status === TaskStatus.Active ? -1 : 1;
+    });
+  }
+
+}

--- a/src/main/webapp/app/tasks/task-list/task-list.animation.ts
+++ b/src/main/webapp/app/tasks/task-list/task-list.animation.ts
@@ -1,0 +1,74 @@
+import {animate, query, stagger, style, transition, trigger} from "@angular/animations";
+
+export const listItemAnimation = trigger('list-item', [
+  transition(':enter', [
+   style({
+      height: 0,
+      opacity: 0,
+      transform: 'scale(0. 85)',
+      marginBottom: 0,
+      padding: 0
+    }),
+    animate(50, style({
+      height: '*',
+      marginBottom: '*',
+      padding: '*'
+    })),
+    animate(100)
+  ]),
+  transition(':leave', [
+    animate(50, style({
+      transform: 'scale(1.05)'
+    })),
+    animate(50, style({
+      transform: 'scale(1)',
+      opacity: 0.75
+    })),
+    animate('120ms ease-out', style({
+      transform: 'scale(0.5)',
+      opacity: 0
+    })),
+    animate('150ms ease-out', style({
+      height: 0,
+      marginBottom: 0,
+      padding: 0
+    }))
+  ])
+]);
+
+/**
+ * Triggers animation only if multiple elements were added or removed
+ * Is used with list number, so input params in fact are numbers
+ *
+ *  @param from number on last animation trigger
+ * @param to current number of elements
+ */
+function multipleListItemsChanged(from: string, to: string): boolean {
+  return Math.abs(Number(from) - Number(to)) >= 2;
+}
+
+export const listAnimation = trigger('list', [
+  transition(multipleListItemsChanged, [
+    query(':enter', [
+      style({
+        height: 0,
+        opacity: 0
+      }),
+      stagger(100, [
+        animate('0.2s ease')
+      ])
+    ], {
+      optional: true
+    }),
+    query(':leave', [
+      stagger(-100, [
+        animate('0.2s ease', style({
+          opacity: 0,
+          transform: 'scale(0.5)'
+        })),
+      ])
+    ], {
+      optional: true
+    })
+  ])
+]);

--- a/src/main/webapp/app/tasks/task-list/task-list.component.html
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.html
@@ -1,6 +1,6 @@
-<mat-list data-cy="task-list">
+<mat-list [@list]="tasks.length" data-cy="task-list">
   <ng-template ngFor let-task [ngForOf]="tasks | sortTasks" [ngForTrackBy]="trackByTaskId" class="mat-elevation-z1">
-    <mat-list-item *tinyLet="isTaskFinished(task) as isTaskFinished">
+    <mat-list-item @list-item *tinyLet="isTaskFinished(task) as isTaskFinished">
       <mat-icon
         mat-list-icon
         class="task-status"

--- a/src/main/webapp/app/tasks/task-list/task-list.component.html
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.html
@@ -1,5 +1,5 @@
 <mat-list data-cy="task-list">
-  <mat-list-item *ngFor="let task of tasks; trackBy: trackByTaskId" class="mat-elevation-z1">
+  <mat-list-item *ngFor="let task of tasks | sortTasks; trackBy: trackByTaskId" class="mat-elevation-z1">
     <mat-icon mat-list-icon>assignment</mat-icon>
     <h4 mat-line>{{task.name}}</h4>
     <button *ngIf="!isTaskDone(task)" mat-icon-button (click)="markAsDone(task)" class="mark-as-done-action" aria-label="Mark task as done">

--- a/src/main/webapp/app/tasks/task-list/task-list.component.html
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.html
@@ -1,49 +1,50 @@
 <mat-list data-cy="task-list">
-  <mat-list-item *ngFor="let task of tasks | sortTasks; trackBy: trackByTaskId" class="mat-elevation-z1">
-    <mat-icon
-      mat-list-icon
-      class="task-status"
-      [ngClass]="{
+  <ng-template ngFor let-task [ngForOf]="tasks | sortTasks" [ngForTrackBy]="trackByTaskId" class="mat-elevation-z1">
+    <mat-list-item *tinyLet="isTaskFinished(task) as isTaskFinished">
+      <mat-icon
+        mat-list-icon
+        class="task-status"
+        [ngClass]="{
         'todo': task.status === taskStatus.Todo,
         'done': task.status === taskStatus.Done,
         'in-progress': task.status === taskStatus.InProgress,
         'blocked': task.status === taskStatus.Blocked,
         'cancelled': task.status === taskStatus.Cancelled
-      }"
-    >assignment</mat-icon>
-    <h4 mat-line>{{task.name}}</h4>
-    <button
-      *ngIf="!isTaskFinished(task)"
-      mat-icon-button
-      (click)="changeStatus(task.id, taskStatus.Done)"
-      class="task-status done"
-      aria-label="Mark task as done"
-    >
-      <mat-icon>done</mat-icon>
-    </button>
-    <button mat-icon-button (click)="delete(task)" class="delete-action" aria-label="Delete task">
-      <mat-icon>delete</mat-icon>
-    </button>
-    <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="More actions for task">
-      <mat-icon>more_vert</mat-icon>
-    </button>
-    <mat-menu #menu="matMenu">
-      <button *ngIf="isTaskFinished(task)" mat-menu-item (click)="changeStatus(task.id, taskStatus.Todo)" aria-label="Reopen task to todo">
-        <mat-icon class="task-status todo">compare_arrows</mat-icon>
-        Reopen
+      }">assignment</mat-icon>
+      <h4 mat-line>{{task.name}}</h4>
+      <button
+        *ngIf="!isTaskFinished"
+        mat-icon-button
+        (click)="changeStatus(task.id, taskStatus.Done)"
+        class="task-status done"
+        aria-label="Mark task as done"
+      >
+        <mat-icon>done</mat-icon>
       </button>
-      <button *ngIf="!isTaskFinished(task) && task.status !== taskStatus.InProgress" mat-menu-item (click)="changeStatus(task.id, taskStatus.InProgress)" aria-label="Start progress on task">
-        <mat-icon class="task-status in-progress">more_horiz</mat-icon>
-        Start Progress
+      <button mat-icon-button (click)="delete(task)" class="delete-action" aria-label="Delete task">
+        <mat-icon>delete</mat-icon>
       </button>
-      <button *ngIf="!isTaskFinished(task) && task.status !== taskStatus.Blocked" mat-menu-item (click)="changeStatus(task.id, taskStatus.Blocked)" aria-label="Mark task as blocked">
-        <mat-icon class="task-status blocked">schedule</mat-icon>
-        Mark as Blocked
+      <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="More actions for task">
+        <mat-icon>more_vert</mat-icon>
       </button>
-      <button *ngIf="!isTaskFinished(task)" mat-menu-item (click)="changeStatus(task.id, taskStatus.Cancelled)" aria-label="Cancel task">
-        <mat-icon class="task-status cancelled">close</mat-icon>
-        Cancel
-      </button>
-    </mat-menu>
-  </mat-list-item>
+      <mat-menu #menu="matMenu">
+        <button *ngIf="task.status !== taskStatus.Todo" mat-menu-item (click)="changeStatus(task.id, taskStatus.Todo)" aria-label="Reopen task to todo">
+          <mat-icon class="task-status todo">compare_arrows</mat-icon>
+          Reopen
+        </button>
+        <button *ngIf="!isTaskFinished && task.status !== taskStatus.InProgress" mat-menu-item (click)="changeStatus(task.id, taskStatus.InProgress)" aria-label="Start progress on task">
+          <mat-icon class="task-status in-progress">more_horiz</mat-icon>
+          Start Progress
+        </button>
+        <button *ngIf="!isTaskFinished && task.status !== taskStatus.Blocked" mat-menu-item (click)="changeStatus(task.id, taskStatus.Blocked)" aria-label="Mark task as blocked">
+          <mat-icon class="task-status blocked">schedule</mat-icon>
+          Mark as Blocked
+        </button>
+        <button *ngIf="!isTaskFinished" mat-menu-item (click)="changeStatus(task.id, taskStatus.Cancelled)" aria-label="Cancel task">
+          <mat-icon class="task-status cancelled">close</mat-icon>
+          Cancel
+        </button>
+      </mat-menu>
+    </mat-list-item>
+  </ng-template>
 </mat-list>

--- a/src/main/webapp/app/tasks/task-list/task-list.component.html
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.html
@@ -13,7 +13,7 @@
     >assignment</mat-icon>
     <h4 mat-line>{{task.name}}</h4>
     <button
-      *ngIf="!isTaskDone(task)"
+      *ngIf="!isTaskFinished(task)"
       mat-icon-button
       (click)="changeStatus(task.id, taskStatus.Done)"
       class="task-status done"
@@ -24,19 +24,19 @@
     <button mat-icon-button (click)="delete(task)" class="delete-action" aria-label="Delete task">
       <mat-icon>delete</mat-icon>
     </button>
-    <button *ngIf="!isTaskDone(task)" mat-icon-button [matMenuTriggerFor]="menu" aria-label="More actions for task">
+    <button *ngIf="!isTaskFinished(task)" mat-icon-button [matMenuTriggerFor]="menu" aria-label="More actions for task">
       <mat-icon>more_vert</mat-icon>
     </button>
     <mat-menu #menu="matMenu">
-      <button mat-menu-item (click)="changeStatus(task.id, taskStatus.InProgress)">
+      <button mat-menu-item (click)="changeStatus(task.id, taskStatus.InProgress)" aria-label="Start progress on task">
         <mat-icon class="task-status in-progress">east</mat-icon>
         Start Progress
       </button>
-      <button mat-menu-item (click)="changeStatus(task.id, taskStatus.Blocked)">
+      <button mat-menu-item (click)="changeStatus(task.id, taskStatus.Blocked)" aria-label="Mark task as blocked">
         <mat-icon class="task-status blocked">schedule</mat-icon>
         Mark as Blocked
       </button>
-      <button mat-menu-item (click)="changeStatus(task.id, taskStatus.Cancelled)">
+      <button mat-menu-item (click)="changeStatus(task.id, taskStatus.Cancelled)" aria-label="Cancel task">
         <mat-icon class="task-status cancelled">close</mat-icon>
         Cancel
       </button>

--- a/src/main/webapp/app/tasks/task-list/task-list.component.html
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.html
@@ -1,9 +1,12 @@
 <mat-list data-cy="task-list">
-  <mat-list-item *ngFor="let task of tasks" class="mat-elevation-z1">
+  <mat-list-item *ngFor="let task of tasks; trackBy: trackByTaskId" class="mat-elevation-z1">
     <mat-icon mat-list-icon>assignment</mat-icon>
     <h4 mat-line>{{task.name}}</h4>
-    <button mat-icon-button aria-label="Delete task" color="primary">
-      <mat-icon aria-label="Delete task" (click)="delete(task)">delete</mat-icon>
+    <button *ngIf="!isTaskDone(task)" mat-icon-button (click)="markAsDone(task)" class="mark-as-done-action" aria-label="Mark task as done">
+      <mat-icon>done</mat-icon>
+    </button>
+    <button mat-icon-button (click)="delete(task)" class="delete-action" aria-label="Delete task">
+      <mat-icon>delete</mat-icon>
     </button>
   </mat-list-item>
 </mat-list>

--- a/src/main/webapp/app/tasks/task-list/task-list.component.html
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.html
@@ -1,12 +1,45 @@
 <mat-list data-cy="task-list">
   <mat-list-item *ngFor="let task of tasks | sortTasks; trackBy: trackByTaskId" class="mat-elevation-z1">
-    <mat-icon mat-list-icon>assignment</mat-icon>
+    <mat-icon
+      mat-list-icon
+      class="task-status"
+      [ngClass]="{
+        'todo': task.status === taskStatus.Todo,
+        'done': task.status === taskStatus.Done,
+        'in-progress': task.status === taskStatus.InProgress,
+        'blocked': task.status === taskStatus.Blocked,
+        'cancelled': task.status === taskStatus.Cancelled
+      }"
+    >assignment</mat-icon>
     <h4 mat-line>{{task.name}}</h4>
-    <button *ngIf="!isTaskDone(task)" mat-icon-button (click)="markAsDone(task)" class="mark-as-done-action" aria-label="Mark task as done">
+    <button
+      *ngIf="!isTaskDone(task)"
+      mat-icon-button
+      (click)="changeStatus(task.id, taskStatus.Done)"
+      class="task-status done"
+      aria-label="Mark task as done"
+    >
       <mat-icon>done</mat-icon>
     </button>
     <button mat-icon-button (click)="delete(task)" class="delete-action" aria-label="Delete task">
       <mat-icon>delete</mat-icon>
     </button>
+    <button *ngIf="!isTaskDone(task)" mat-icon-button [matMenuTriggerFor]="menu" aria-label="More actions for task">
+      <mat-icon>more_vert</mat-icon>
+    </button>
+    <mat-menu #menu="matMenu">
+      <button mat-menu-item (click)="changeStatus(task.id, taskStatus.InProgress)">
+        <mat-icon class="task-status in-progress">east</mat-icon>
+        Start Progress
+      </button>
+      <button mat-menu-item (click)="changeStatus(task.id, taskStatus.Blocked)">
+        <mat-icon class="task-status blocked">schedule</mat-icon>
+        Mark as Blocked
+      </button>
+      <button mat-menu-item (click)="changeStatus(task.id, taskStatus.Cancelled)">
+        <mat-icon class="task-status cancelled">close</mat-icon>
+        Cancel
+      </button>
+    </mat-menu>
   </mat-list-item>
 </mat-list>

--- a/src/main/webapp/app/tasks/task-list/task-list.component.html
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.html
@@ -24,19 +24,23 @@
     <button mat-icon-button (click)="delete(task)" class="delete-action" aria-label="Delete task">
       <mat-icon>delete</mat-icon>
     </button>
-    <button *ngIf="!isTaskFinished(task)" mat-icon-button [matMenuTriggerFor]="menu" aria-label="More actions for task">
+    <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="More actions for task">
       <mat-icon>more_vert</mat-icon>
     </button>
     <mat-menu #menu="matMenu">
-      <button mat-menu-item (click)="changeStatus(task.id, taskStatus.InProgress)" aria-label="Start progress on task">
-        <mat-icon class="task-status in-progress">east</mat-icon>
+      <button *ngIf="isTaskFinished(task)" mat-menu-item (click)="changeStatus(task.id, taskStatus.Todo)" aria-label="Reopen task to todo">
+        <mat-icon class="task-status todo">compare_arrows</mat-icon>
+        Reopen
+      </button>
+      <button *ngIf="!isTaskFinished(task) && task.status !== taskStatus.InProgress" mat-menu-item (click)="changeStatus(task.id, taskStatus.InProgress)" aria-label="Start progress on task">
+        <mat-icon class="task-status in-progress">more_horiz</mat-icon>
         Start Progress
       </button>
-      <button mat-menu-item (click)="changeStatus(task.id, taskStatus.Blocked)" aria-label="Mark task as blocked">
+      <button *ngIf="!isTaskFinished(task) && task.status !== taskStatus.Blocked" mat-menu-item (click)="changeStatus(task.id, taskStatus.Blocked)" aria-label="Mark task as blocked">
         <mat-icon class="task-status blocked">schedule</mat-icon>
         Mark as Blocked
       </button>
-      <button mat-menu-item (click)="changeStatus(task.id, taskStatus.Cancelled)" aria-label="Cancel task">
+      <button *ngIf="!isTaskFinished(task)" mat-menu-item (click)="changeStatus(task.id, taskStatus.Cancelled)" aria-label="Cancel task">
         <mat-icon class="task-status cancelled">close</mat-icon>
         Cancel
       </button>

--- a/src/main/webapp/app/tasks/task-list/task-list.component.scss
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.scss
@@ -8,7 +8,12 @@
     user-select: none;
   }
 
-  button .mat-icon {
-    color: #101d30;
-  }
+}
+
+.delete-action {
+  color: #101d30;
+}
+
+.mark-as-done-action {
+  color: #9bbf29;
 }

--- a/src/main/webapp/app/tasks/task-list/task-list.component.scss
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.scss
@@ -1,19 +1,41 @@
+$accent: #9bbf29;
+$primary: #101d30;
+$active: #836eda;
+$blocked: #4391ea;
+$error: #f85b29;
+$warning: #ffbf21;
+
 .mat-list-item {
   background: #fff;
   margin: 16px 0;
   border-radius: 4px;
 
   .mat-list-icon {
-    color: #9bbf29;
     user-select: none;
   }
-
 }
 
 .delete-action {
-  color: #101d30;
+  color: $primary;
 }
 
-.mark-as-done-action {
-  color: #9bbf29;
+.task-status {
+  &.todo {
+    color: $warning;
+  }
+  &.done {
+    color: $accent;
+  }
+
+  &.in-progress {
+    color: $active;
+  }
+
+  &.blocked {
+    color: $blocked;
+  }
+
+  &.cancelled {
+    color: $error;
+  }
 }

--- a/src/main/webapp/app/tasks/task-list/task-list.component.spec.ts
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.spec.ts
@@ -1,8 +1,9 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { of } from 'rxjs';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {of} from 'rxjs';
 
-import { TaskService } from '../task.service';
-import { TaskListComponent } from './task-list.component';
+import {TaskService} from '../task.service';
+import {TaskListComponent} from './task-list.component';
+import {TaskStatus} from "app/tasks/task";
 
 describe('TaskListComponent', () => {
   let component: TaskListComponent;
@@ -10,7 +11,7 @@ describe('TaskListComponent', () => {
   let taskService: jasmine.SpyObj<TaskService>;
 
   beforeEach(waitForAsync(() => {
-    taskService = jasmine.createSpyObj('taskService', ['delete']);
+    taskService = jasmine.createSpyObj('taskService', ['delete', 'setStatus']);
     TestBed.configureTestingModule({
       declarations: [TaskListComponent],
       providers: [{
@@ -36,7 +37,7 @@ describe('TaskListComponent', () => {
     taskService.delete.and.returnValue(of(null));
 
     // when
-    component.delete({id: 'id', name: 'My task'});
+    component.delete({id: 'id', name: 'My task', status: TaskStatus.Todo});
 
     // then
     expect(taskService.delete).toHaveBeenCalledWith('id');
@@ -48,9 +49,40 @@ describe('TaskListComponent', () => {
     const deleteEmitter = spyOn(component.deleted, 'emit');
 
     // when
-    component.delete({id: 'id', name: 'My task'});
+    component.delete({id: 'id', name: 'My task', status: TaskStatus.Todo});
 
     // then
-    expect(deleteEmitter).toHaveBeenCalledWith({id: 'id', name: 'My task'});
+    expect(deleteEmitter).toHaveBeenCalledWith({id: 'id', name: 'My task', status: TaskStatus.Todo});
   });
+
+  it('should set new status for a task', () => {
+    // given
+    taskService.setStatus.and.returnValue(of({id: 'id', name: 'My task', status: TaskStatus.Done}));
+
+    // when
+    component.changeStatus('id', TaskStatus.Done);
+
+    // then
+    expect(taskService.setStatus).toHaveBeenCalledWith('id',  TaskStatus.Done);
+  });
+
+  it('should emit updated task after setting new status', () => {
+    // given
+    taskService.setStatus.and.returnValue(of({id: 'id', name: 'My task', status: TaskStatus.Done}));
+    const changeStatusEmitter = spyOn(component.statusChanged, 'emit');
+
+    // when
+    component.changeStatus('id', TaskStatus.Done);
+
+    // then
+    expect(changeStatusEmitter).toHaveBeenCalledWith({id: 'id', name: 'My task', status: TaskStatus.Done});
+  });
+
+  it('should consider only "canceled" and "done" statuses as finished', () => {
+    expect(component.isTaskFinished({id: 'id', name: 'My task', status: TaskStatus.Done})).toBe(true);
+    expect(component.isTaskFinished({id: 'id', name: 'My task', status: TaskStatus.Cancelled})).toBe(true);
+    expect(component.isTaskFinished({id: 'id', name: 'My task', status: TaskStatus.Todo})).toBe(false);
+    expect(component.isTaskFinished({id: 'id', name: 'My task', status: TaskStatus.Blocked})).toBe(false);
+    expect(component.isTaskFinished({id: 'id', name: 'My task', status: TaskStatus.InProgress})).toBe(false);
+  })
 });

--- a/src/main/webapp/app/tasks/task-list/task-list.component.ts
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.ts
@@ -1,6 +1,6 @@
 import {ChangeDetectionStrategy, Component, EventEmitter, Inject, Input, Output} from '@angular/core';
 
-import {Task, TaskStatus} from '../task';
+import {FINISHED_TASK_STATUSES, Task, TaskStatus} from '../task';
 import {TaskService} from '../task.service';
 
 /**
@@ -19,6 +19,8 @@ export class TaskListComponent {
   @Output() public readonly deleted: EventEmitter<Task> = new EventEmitter();
   @Output() public readonly statusChanged: EventEmitter<Task> = new EventEmitter();
 
+  public taskStatus: typeof TaskStatus = TaskStatus;
+
   constructor(
     @Inject('TaskService') private taskService: TaskService
   ) { }
@@ -33,13 +35,13 @@ export class TaskListComponent {
     });
   }
 
-  public markAsDone(task: Task): void {
-    this.taskService.setStatus(task.id, TaskStatus.Done).subscribe((updatedTask: Task) => {
+  public changeStatus(id: string, status: TaskStatus): void {
+    this.taskService.setStatus(id, status).subscribe((updatedTask: Task) => {
       this.statusChanged.emit(updatedTask);
     });
   }
 
   public isTaskDone(task: Task): boolean {
-    return task.status === TaskStatus.Done;
+    return FINISHED_TASK_STATUSES.includes(task.status);
   }
 }

--- a/src/main/webapp/app/tasks/task-list/task-list.component.ts
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.ts
@@ -14,7 +14,7 @@ import {TaskService} from '../task.service';
 })
 export class TaskListComponent {
 
-  @Input() public readonly tasks: Task[];
+  @Input() public readonly tasks: ReadonlyArray<Task> = [];
 
   @Output() public readonly deleted: EventEmitter<Task> = new EventEmitter();
   @Output() public readonly statusChanged: EventEmitter<Task> = new EventEmitter();
@@ -25,7 +25,7 @@ export class TaskListComponent {
     @Inject('TaskService') private taskService: TaskService
   ) { }
 
-  public trackByTaskId(_, task: Task): string {
+  public trackByTaskId(_: any, task: Task): string {
     return task.id;
   }
 

--- a/src/main/webapp/app/tasks/task-list/task-list.component.ts
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.ts
@@ -41,7 +41,7 @@ export class TaskListComponent {
     });
   }
 
-  public isTaskDone(task: Task): boolean {
+  public isTaskFinished(task: Task): boolean {
     return FINISHED_TASK_STATUSES.includes(task.status);
   }
 }

--- a/src/main/webapp/app/tasks/task-list/task-list.component.ts
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.ts
@@ -1,7 +1,7 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Inject, Input, Output } from '@angular/core';
+import {ChangeDetectionStrategy, Component, EventEmitter, Inject, Input, Output} from '@angular/core';
 
-import { Task } from '../task';
-import { TaskService } from '../task.service';
+import {Task, TaskStatus} from '../task';
+import {TaskService} from '../task.service';
 
 /**
  * A list of tiny tasks.
@@ -14,15 +14,32 @@ import { TaskService } from '../task.service';
 })
 export class TaskListComponent {
 
-  @Input() tasks: Task[];
+  @Input() public readonly tasks: Task[];
 
-  @Output() deleted: EventEmitter<Task> = new EventEmitter();
+  @Output() public readonly deleted: EventEmitter<Task> = new EventEmitter();
+  @Output() public readonly statusChanged: EventEmitter<Task> = new EventEmitter();
 
-  constructor(@Inject('TaskService') private taskService: TaskService) { }
+  constructor(
+    @Inject('TaskService') private taskService: TaskService
+  ) { }
 
-  delete(task: Task): void {
+  public trackByTaskId(_, task: Task): string {
+    return task.id;
+  }
+
+  public delete(task: Task): void {
     this.taskService.delete(task.id).subscribe(() => {
       this.deleted.emit(task);
     });
+  }
+
+  public markAsDone(task: Task): void {
+    this.taskService.setStatus(task.id, TaskStatus.Done).subscribe((updatedTask: Task) => {
+      this.statusChanged.emit(updatedTask);
+    });
+  }
+
+  public isTaskDone(task: Task): boolean {
+    return task.status === TaskStatus.Done;
   }
 }

--- a/src/main/webapp/app/tasks/task-list/task-list.component.ts
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.ts
@@ -2,6 +2,7 @@ import {ChangeDetectionStrategy, Component, EventEmitter, Inject, Input, Output}
 
 import {FINISHED_TASK_STATUSES, Task, TaskStatus} from '../task';
 import {TaskService} from '../task.service';
+import {listAnimation, listItemAnimation} from "app/tasks/task-list/task-list.animation";
 
 /**
  * A list of tiny tasks.
@@ -10,7 +11,11 @@ import {TaskService} from '../task.service';
   selector: 'tiny-task-list',
   templateUrl: './task-list.component.html',
   styleUrls: ['./task-list.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [
+    listAnimation,
+    listItemAnimation
+  ]
 })
 export class TaskListComponent {
 

--- a/src/main/webapp/app/tasks/task.service.ts
+++ b/src/main/webapp/app/tasks/task.service.ts
@@ -28,12 +28,20 @@ export interface TaskService {
    * @param id the ID of the task to be removed
    * @returns an empty `Observable`
    */
-  delete(id: string): Observable<void>;
+  delete(id: string): Observable<null>;
+
+  /**
+   * Removed tasks with given IDs from the list of tasks
+   * @param ids list of IDs of tasks to be removed
+   * @returns an empty `Observable`
+   */
+  deleteAll(ids: string[]): Observable<null>;
 
   /**
    *
    * @param id the ID of the task to status change
    * @param status new task lifecycle state
+   * @returns an `Observable` holding the updated task
    */
   setStatus(id: string, status: TaskStatus): Observable<Task>;
 

--- a/src/main/webapp/app/tasks/task.service.ts
+++ b/src/main/webapp/app/tasks/task.service.ts
@@ -28,14 +28,14 @@ export interface TaskService {
    * @param id the ID of the task to be removed
    * @returns an empty `Observable`
    */
-  delete(id: string): Observable<null>;
+  delete(id: string): Observable<void>;
 
   /**
    * Removed tasks with given IDs from the list of tasks
    * @param ids list of IDs of tasks to be removed
    * @returns an empty `Observable`
    */
-  deleteAll(ids: string[]): Observable<null>;
+  deleteAll(ids: string[]): Observable<void>;
 
   /**
    *

--- a/src/main/webapp/app/tasks/task.service.ts
+++ b/src/main/webapp/app/tasks/task.service.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 
-import { Task } from 'app/tasks/task';
+import {Task, TaskStatus} from 'app/tasks/task';
 
 /**
  * Service interface for implementations that handle tiny tasks.
@@ -29,4 +29,12 @@ export interface TaskService {
    * @returns an empty `Observable`
    */
   delete(id: string): Observable<void>;
+
+  /**
+   *
+   * @param id the ID of the task to status change
+   * @param status new task lifecycle state
+   */
+  setStatus(id: string, status: TaskStatus): Observable<Task>;
+
 }

--- a/src/main/webapp/app/tasks/task.ts
+++ b/src/main/webapp/app/tasks/task.ts
@@ -1,7 +1,12 @@
+export enum TaskStatus {
+  Active,
+  Done
+}
 /**
  * A tiny task.
  */
 export interface Task {
   id: string;
   name: string;
+  status: TaskStatus;
 }

--- a/src/main/webapp/app/tasks/task.ts
+++ b/src/main/webapp/app/tasks/task.ts
@@ -1,7 +1,18 @@
+/**
+ * Task lifecycle statuses
+ */
 export enum TaskStatus {
-  Active,
-  Done
+  Todo,
+  Blocked,
+  InProgress,
+  Done,
+  Cancelled
 }
+
+/**
+ * Task statuses which are considered as completed
+ */
+export const FINISHED_TASK_STATUSES = [TaskStatus.Done, TaskStatus.Cancelled];
 /**
  * A tiny task.
  */

--- a/src/main/webapp/app/tasks/tasks.module.ts
+++ b/src/main/webapp/app/tasks/tasks.module.ts
@@ -9,6 +9,7 @@ import { MatListModule } from '@angular/material/list';
 import { TaskFormComponent } from './task-form/task-form.component';
 import { TaskListComponent } from './task-list/task-list.component';
 import { SortTasksPipe } from './task-list/sort-tasks.pipe';
+import {MatMenuModule} from "@angular/material/menu";
 
 @NgModule({
   declarations: [TaskFormComponent, TaskListComponent, SortTasksPipe],
@@ -18,7 +19,8 @@ import { SortTasksPipe } from './task-list/sort-tasks.pipe';
     MatButtonModule,
     MatIconModule,
     MatInputModule,
-    MatListModule
+    MatListModule,
+    MatMenuModule
   ],
   exports: [TaskFormComponent, TaskListComponent]
 })

--- a/src/main/webapp/app/tasks/tasks.module.ts
+++ b/src/main/webapp/app/tasks/tasks.module.ts
@@ -8,9 +8,10 @@ import { MatListModule } from '@angular/material/list';
 
 import { TaskFormComponent } from './task-form/task-form.component';
 import { TaskListComponent } from './task-list/task-list.component';
+import { SortTasksPipe } from './task-list/sort-tasks.pipe';
 
 @NgModule({
-  declarations: [TaskFormComponent, TaskListComponent],
+  declarations: [TaskFormComponent, TaskListComponent, SortTasksPipe],
   imports: [
     CommonModule,
     ReactiveFormsModule,

--- a/src/main/webapp/app/tasks/tasks.module.ts
+++ b/src/main/webapp/app/tasks/tasks.module.ts
@@ -10,6 +10,7 @@ import { TaskFormComponent } from './task-form/task-form.component';
 import { TaskListComponent } from './task-list/task-list.component';
 import { SortTasksPipe } from './task-list/sort-tasks.pipe';
 import {MatMenuModule} from "@angular/material/menu";
+import {SharedModule} from "app/shared/shared.module";
 
 @NgModule({
   declarations: [TaskFormComponent, TaskListComponent, SortTasksPipe],
@@ -20,7 +21,8 @@ import {MatMenuModule} from "@angular/material/menu";
     MatIconModule,
     MatInputModule,
     MatListModule,
-    MatMenuModule
+    MatMenuModule,
+    SharedModule,
   ],
   exports: [TaskFormComponent, TaskListComponent]
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "strict": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "outDir": "./dist/out-tsc",
@@ -22,5 +23,9 @@
       "es2017",
       "dom"
     ]
+  },
+  "angularCompilerOptions": {
+    "fullTemplateTypeCheck": true,
+    "strictTemplates": true
   }
 }


### PR DESCRIPTION
Implemented frontend for #29 with local environment

Tasks can be marked as Done and also support other statuses (In Progress, Blocked, Cancelled)
Tasks are sorted with Todo on top (and overall order is: Todo, In Progress, Blocked, Done, Cancelled)
User is able to clear all finished tasks (Done and Cancelled) with button on top

All introduced functionality is covered with tests

Also animation of element addition and removal was added

![image](https://user-images.githubusercontent.com/25702900/124200670-99a11e00-dade-11eb-9228-bdc1a3fe2de3.png)