### PR TITLE
"A user can mark a task as done" feature

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -172,6 +172,7 @@
   },
   "defaultProject": "tiny-tasks",
   "cli": {
+    "analytics": false,
     "defaultCollection": "@angular-eslint/schematics"
   }
 }

--- a/src/main/webapp/app/tasks/default-task.service.ts
+++ b/src/main/webapp/app/tasks/default-task.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 import { BASE_URL } from '../app.tokens';
 import { Task } from './task';
@@ -13,7 +13,7 @@ export class DefaultTaskService implements TaskService {
   }
 
   create(name: string): Observable<Task> {
-    return this.http.post<Task>(this.baseUrl + '/tasks', { name } as Task);
+    return this.http.post<Task>(this.baseUrl + '/tasks', {name} as Task);
   }
 
   delete(id: string): Observable<void> {
@@ -22,5 +22,9 @@ export class DefaultTaskService implements TaskService {
 
   getAll(): Observable<Task[]> {
     return this.http.get<Task[]>(this.baseUrl + '/tasks');
+  }
+
+  public updateTasks(tasks: Task[]): Observable<Task[]> {
+    return of(tasks);
   }
 }

--- a/src/main/webapp/app/tasks/local-task.service.spec.ts
+++ b/src/main/webapp/app/tasks/local-task.service.spec.ts
@@ -62,6 +62,15 @@ describe('LocalTaskService', () => {
     expect(localStorage.setItem).toHaveBeenCalled();
   });
 
+  it('should write sorted tasks to local storage', () => {
+    localStorageGetSpy.and.returnValue('[{"id":"1","name":"1","status":"open"},{"id":"2","name":"2","status":"done"}]');
+    const writeSpy = spyOn<any>(taskService, 'writeTasks');
+    taskService.create('Drinking the drink!');
+
+    const args = writeSpy.calls.mostRecent().args[0] as Task[];
+    expect(args[1].name).toBe('Drinking the drink!');
+  });
+
   it('should delete task from local storage', () => {
     // when
     taskService.delete(id);

--- a/src/main/webapp/app/tasks/local-task.service.ts
+++ b/src/main/webapp/app/tasks/local-task.service.ts
@@ -4,6 +4,7 @@ import { v4 as uuid } from 'uuid';
 
 import { Task } from './task';
 import { TaskService } from './task.service';
+import { Status } from './status';
 
 @Injectable()
 export class LocalTaskService implements TaskService {
@@ -16,8 +17,12 @@ export class LocalTaskService implements TaskService {
 
   create(name: string): Observable<Task> {
     const tasks = this.readTasks();
-    const task = {id: uuid(), name};
-    tasks.push(task);
+    const task = {id: uuid(), name, status: Status.OPEN};
+    let firstDoneIndex = tasks.findIndex(task => task.status === Status.DONE);
+    if (firstDoneIndex < 0) {
+      firstDoneIndex = tasks.length;
+    }
+    tasks.splice(firstDoneIndex, 0, task);
     this.writeTasks(tasks);
     return of(task);
   }
@@ -30,6 +35,11 @@ export class LocalTaskService implements TaskService {
       this.writeTasks(tasks);
     }
     return of(void 0);
+  }
+
+  public updateTasks(tasks: Task[]): Observable<Task[]> {
+    this.writeTasks(tasks);
+    return of(tasks);
   }
 
   private readTasks(): Task[] {

--- a/src/main/webapp/app/tasks/status.ts
+++ b/src/main/webapp/app/tasks/status.ts
@@ -1,0 +1,7 @@
+export enum Status {
+  DONE = 'done',
+  OPEN = 'open',
+  IN_PROGRESS = 'in progress',
+  BLOCKED = 'blocked',
+  WAITING = 'waiting'
+}

--- a/src/main/webapp/app/tasks/task-form/task-form.component.spec.ts
+++ b/src/main/webapp/app/tasks/task-form/task-form.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { of } from 'rxjs';
 
 import { TaskService } from '../task.service';
+import { Status } from '../status';
 import { TaskFormComponent } from './task-form.component';
 
 describe('TaskFormComponent', () => {
@@ -34,7 +35,7 @@ describe('TaskFormComponent', () => {
   it('should create a task', () => {
     // given
     component.taskForm.setValue({ name: 'My task' });
-    taskService.create.and.returnValue(of({ id: 'id', name: 'My task' }));
+    taskService.create.and.returnValue(of({ id: 'id', name: 'My task', status: Status.OPEN }));
 
     // when
     component.onSubmit();
@@ -57,20 +58,20 @@ describe('TaskFormComponent', () => {
   it('should emit the task after creation', () => {
     // given
     component.taskForm.setValue({ name: 'My task' });
-    taskService.create.and.returnValue(of({ id: 'id', name: 'My task' }));
+    taskService.create.and.returnValue(of({ id: 'id', name: 'My task', status: Status.OPEN }));
     const createEmitter = spyOn(component.created, 'emit');
 
     // when
     component.onSubmit();
 
     // then
-    expect(createEmitter).toHaveBeenCalledWith({ id: 'id', name: 'My task' });
+    expect(createEmitter).toHaveBeenCalledWith({ id: 'id', name: 'My task', status: Status.OPEN });
   });
 
   it('should reset the form after creation', () => {
     // given
     component.taskForm.setValue({ name: 'My task' });
-    taskService.create.and.returnValue(of({ id: 'id', name: 'My task' }));
+    taskService.create.and.returnValue(of({ id: 'id', name: 'My task', status: Status.OPEN }));
     const formReset = spyOn(component.taskForm, 'reset');
 
     // when

--- a/src/main/webapp/app/tasks/task-list/task-list.component.html
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.html
@@ -1,9 +1,68 @@
-<mat-list data-cy="task-list">
-  <mat-list-item *ngFor="let task of tasks" class="mat-elevation-z1">
-    <mat-icon mat-list-icon>assignment</mat-icon>
-    <h4 mat-line>{{task.name}}</h4>
-    <button mat-icon-button aria-label="Delete task" color="primary">
-      <mat-icon aria-label="Delete task" (click)="delete(task)">delete</mat-icon>
-    </button>
-  </mat-list-item>
-</mat-list>
+<div cdkDropListGroup>
+  <div class="list-container">
+    <h2>To do</h2>
+    <mat-list
+      cdkDropList
+      #todoList="cdkDropList"
+      [cdkDropListData]="openTasks"
+      [cdkDropListConnectedTo]="[doneList]"
+      (cdkDropListDropped)="dropToOpen($event)">
+
+      <mat-list-item
+        *ngFor="let task of openTasks;  index as i"
+        cdkDrag
+        cdkDragPreviewContainer="parent"
+        [cdkDragData]="task"
+      >
+        <ng-container
+          *ngTemplateOutlet="listItemContent; context:{$implicit: task, list:'openTasks', index: i}"
+        ></ng-container>
+      </mat-list-item>
+
+    </mat-list>
+  </div>
+
+  <div class="list-container">
+    <div>
+      <h2>Done</h2>
+      <button *ngIf="doneTasks.length" (click)="clearDoneTasks()">Clear done tasks</button>
+    </div>
+
+    <mat-list
+      cdkDropList
+      #doneList="cdkDropList"
+      [cdkDropListData]="doneTasks"
+      [cdkDropListConnectedTo]="[todoList]"
+      (cdkDropListDropped)="dropToDone($event)">
+
+      <mat-list-item
+        *ngFor="let task of doneTasks; index as i"
+        cdkDrag
+        cdkDragPreviewContainer="parent"
+        [cdkDragData]="task"
+      >
+        <ng-container
+          *ngTemplateOutlet="listItemContent; context:{$implicit: task, list:'doneTasks', index: i}"
+        ></ng-container>
+      </mat-list-item>
+
+    </mat-list>
+  </div>
+</div>
+
+<ng-template let-item let-list="list" let-index="index" #listItemContent>
+  <mat-icon mat-list-icon *ngIf="isTaskDone(item) else openTaskIcon">assignment_turned_in</mat-icon>
+  <div class="mat-list-text">
+    <p class="mat-line">
+      <span>{{item.name}}</span>
+      <button class="task-status" aria-label="change status" (click)="editStatus(list, index)">{{item.status}}</button>
+    </p>
+  </div>
+  <button mat-icon-button aria-label="Delete task" color="primary" class="button-delete">
+    <mat-icon aria-label="Delete task" (click)="delete(item)">delete</mat-icon>
+  </button>
+</ng-template>
+
+<ng-template #openTaskIcon>
+  <mat-icon mat-list-icon>assignment</mat-icon>
+</ng-template>

--- a/src/main/webapp/app/tasks/task-list/task-list.component.scss
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.scss
@@ -12,3 +12,34 @@
     color: #8C559C;
   }
 }
+
+.cdk-drag-placeholder {
+  opacity: 0;
+}
+
+.list-container {
+  h2 {
+    padding-top: 15px;
+    margin-bottom: 0;
+  }
+
+  .task-status {
+    font-style: italic;
+    color: #31BFCE;
+    text-transform: capitalize;
+  }
+}
+
+.button-delete {
+  margin-bottom: 5px;
+}
+
+button {
+  float: right;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 100%;
+  padding: 0;
+}
+

--- a/src/main/webapp/app/tasks/task-list/task-list.component.spec.ts
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.spec.ts
@@ -1,29 +1,51 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
+import { ChangeDetectorRef } from '@angular/core';
+import { CdkDragDrop } from '@angular/cdk/drag-drop';
+import { CdkDropList } from '@angular/cdk/drag-drop/directives/drop-list';
 
-import { TaskService } from '../task.service';
 import { TaskListComponent } from './task-list.component';
+
+import { Status } from '../status';
+import { Task } from '../task';
+import { TaskService } from '../task.service';
 
 describe('TaskListComponent', () => {
   let component: TaskListComponent;
   let fixture: ComponentFixture<TaskListComponent>;
   let taskService: jasmine.SpyObj<TaskService>;
+  let matDialogMock: jasmine.SpyObj<MatDialog>;
+  let changeDetectorRefMock: jasmine.SpyObj<ChangeDetectorRef>;
 
-  beforeEach(waitForAsync(() => {
-    taskService = jasmine.createSpyObj('taskService', ['delete']);
-    TestBed.configureTestingModule({
+  let tasks: Task[];
+  let afterClosedSpy: jasmine.Spy;
+
+  beforeEach(async () => {
+    taskService = jasmine.createSpyObj('taskService', ['delete', 'updateTasks']);
+    matDialogMock = jasmine.createSpyObj('MatDialog', ['open']);
+    changeDetectorRefMock = jasmine.createSpyObj('ChangeDetectorRef', ['detectChanges']);
+
+    afterClosedSpy = jasmine.createSpy();
+    taskService.updateTasks.and.returnValue(of([]));
+    matDialogMock.open.and.returnValue({afterClosed: afterClosedSpy} as any);
+    tasks = [{id: '1', name: 'My task', status: Status.OPEN}, {id: '2', name: 'My task', status: Status.DONE}];
+
+    await TestBed.configureTestingModule({
       declarations: [TaskListComponent],
-      providers: [{
-        provide: 'TaskService',
-        useValue: taskService
-      }]
+      providers: [
+        {provide: 'TaskService', useValue: taskService},
+        {provide: MatDialog, useValue: matDialogMock},
+        {provide: ChangeDetectorRef, useValue: changeDetectorRefMock},
+      ]
     }).overrideTemplate(TaskListComponent, '')
       .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TaskListComponent);
     component = fixture.componentInstance;
+    component.tasks = tasks;
     fixture.detectChanges();
   });
 
@@ -36,7 +58,7 @@ describe('TaskListComponent', () => {
     taskService.delete.and.returnValue(of(void 0));
 
     // when
-    component.delete({id: 'id', name: 'My task'});
+    component.delete({id: 'id', name: 'My task', status: Status.DONE});
 
     // then
     expect(taskService.delete).toHaveBeenCalledWith('id');
@@ -48,9 +70,150 @@ describe('TaskListComponent', () => {
     const deleteEmitter = spyOn(component.deleted, 'emit');
 
     // when
-    component.delete({id: 'id', name: 'My task'});
+    component.delete({id: 'id', name: 'My task', status: Status.DONE});
 
     // then
-    expect(deleteEmitter).toHaveBeenCalledWith({id: 'id', name: 'My task'});
+    expect(deleteEmitter).toHaveBeenCalledWith({id: 'id', name: 'My task', status: Status.DONE});
   });
+
+  it('should set doneTasks on input set', () => {
+    // component.tasks = tasks;
+    expect(component.doneTasks).toEqual([tasks[1]]);
+  });
+
+  it('should set openTasks on input set', () => {
+    // component.tasks = tasks;
+    expect(component.openTasks).toEqual([tasks[0]]);
+  });
+
+  describe('dropToDone -', () => {
+    let dropSpy: jasmine.Spy;
+    beforeEach(() => {
+      dropSpy = spyOn<any>(component, 'drop');
+      component.dropToDone({currentIndex: 0} as CdkDragDrop<Task[]>);
+    })
+
+    it('should call drop', () => {
+      expect(dropSpy).toHaveBeenCalled();
+    });
+
+    it('should update the elements status', () => {
+      expect(component.doneTasks[0].status).toBe(Status.DONE);
+    });
+
+    it('should call updateTasks', () => {
+      expect(taskService.updateTasks).toHaveBeenCalled();
+    });
+  })
+
+  describe('dropToOpen -', () => {
+    let dropSpy: jasmine.Spy;
+    beforeEach(() => {
+      dropSpy = spyOn<any>(component, 'drop');
+      afterClosedSpy.and.returnValue(of(Status.IN_PROGRESS));
+
+      component.dropToOpen({
+        currentIndex: 0,
+        previousContainer: {id: '1'} as CdkDropList<Task[]>,
+        container: {id: '2'} as CdkDropList<Task[]>
+      } as CdkDragDrop<Task[]>);
+    })
+
+    it('should call drop method', () => {
+      expect(dropSpy).toHaveBeenCalled();
+    });
+
+    it('should update the elements status', () => {
+      expect(component.openTasks[0].status).toBe(Status.IN_PROGRESS);
+    });
+
+    it('should call updateTasks', () => {
+      expect(taskService.updateTasks).toHaveBeenCalled();
+    });
+  })
+
+  describe('editStatus -', () => {
+    it('should not change array if no dialog selection', () => {
+      afterClosedSpy.and.returnValue(of(null));
+      component.editStatus('openTasks', 0);
+      expect(component.openTasks).toEqual([tasks[0]]);
+    });
+
+    it('should not change array if status did not change', () => {
+      afterClosedSpy.and.returnValue(of(Status.OPEN));
+      component.editStatus('openTasks', 0);
+      expect(component.openTasks).toEqual([tasks[0]]);
+    });
+
+    describe('moving element to done', () => {
+      beforeEach(() => {
+        afterClosedSpy.and.returnValue(of(Status.DONE));
+        component.editStatus('openTasks', 0);
+      })
+
+      it('should remove element from openTasks', () => {
+        expect(component.openTasks.length).toBe(0);
+      });
+
+      it('should add element from doneTasks', () => {
+        expect(component.doneTasks[0]).toEqual({...tasks[0], status: Status.DONE});
+      });
+
+      it('should call updateTasks', () => {
+        expect(taskService.updateTasks).toHaveBeenCalled();
+      });
+    })
+
+    describe('should moving element to open', () => {
+      beforeEach(() => {
+        afterClosedSpy.and.returnValue(of(Status.OPEN));
+        component.editStatus('doneTasks', 0);
+      })
+
+      it('should remove element from doneTasks', () => {
+        expect(component.doneTasks.length).toBe(0);
+      });
+
+      it('should add element from openTasks', () => {
+        expect(component.openTasks[0]).toEqual({...tasks[1], status: Status.OPEN});
+      });
+
+      it('should call updateTasks', () => {
+        expect(taskService.updateTasks).toHaveBeenCalled();
+      });
+    })
+
+    describe('should changing an elements status', () => {
+      beforeEach(() => {
+        afterClosedSpy.and.returnValue(of(Status.IN_PROGRESS));
+        component.editStatus('openTasks', 0);
+      })
+
+      it('should change status property', () => {
+        expect(component.openTasks[0]).toEqual({...tasks[0], status: Status.IN_PROGRESS});
+      });
+
+      it('should call updateTasks', () => {
+        expect(taskService.updateTasks).toHaveBeenCalled();
+      });
+    })
+
+  })
+  describe('clearDoneTasks -', () => {
+    it('should set doneTasks to empty array', () => {
+      component.clearDoneTasks();
+      expect(component.doneTasks.length).toBe(0);
+    });
+
+    it('should updateTasks', () => {
+      component.clearDoneTasks();
+      expect(taskService.updateTasks).toHaveBeenCalled();
+    });
+  })
+
+  describe('isTaskDone -', () => {
+    it('should true if status is DONE', () => {
+      expect(component.isTaskDone(tasks[1])).toBe(true);
+    });
+  })
 });

--- a/src/main/webapp/app/tasks/task-list/task-list.component.ts
+++ b/src/main/webapp/app/tasks/task-list/task-list.component.ts
@@ -1,7 +1,21 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Inject, Input, Output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Inject,
+  Input,
+  Output
+} from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { CdkDragDrop, moveItemInArray, transferArrayItem } from '@angular/cdk/drag-drop';
+import { first } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 
 import { Task } from '../task';
 import { TaskService } from '../task.service';
+import { Status } from '../status';
+import { TaskStatusDialogComponent } from '../task-status-dialog/task-status-dialog.component';
 
 /**
  * A list of tiny tasks.
@@ -13,16 +27,139 @@ import { TaskService } from '../task.service';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TaskListComponent {
-
-  @Input() tasks: Task[] | null = null;
+  @Input() set tasks(tasks: Task[] | null) {
+    if (Array.isArray(tasks)) {
+      this.setTaskLists(tasks);
+    }
+  }
 
   @Output() deleted: EventEmitter<Task> = new EventEmitter();
 
-  constructor(@Inject('TaskService') private taskService: TaskService) {}
+  public doneTasks: Task[] = [];
+  public openTasks: Task[] = [];
+
+  constructor(
+    @Inject('TaskService') private taskService: TaskService,
+    public dialog: MatDialog,
+    public cd: ChangeDetectorRef
+  ) {
+  }
+
 
   delete(task: Task): void {
-    this.taskService.delete(task.id).subscribe(() => {
-      this.deleted.emit(task);
+    this.taskService.delete(task.id).subscribe({
+      next: () => {
+        this.deleted.emit(task);
+      }
     });
   }
+
+  public dropToDone(event: CdkDragDrop<Task[]>): void {
+    this.drop(event);
+    this.doneTasks[event.currentIndex].status = Status.DONE;
+    this.updateTasks();
+  }
+
+  public dropToOpen(event: CdkDragDrop<Task[]>): void {
+    this.drop(event);
+
+    if (event.previousContainer.id !== event.container.id) {
+      this.getDialogSelection().subscribe({
+        next: result => {
+          this.openTasks[event.currentIndex].status = result || Status.OPEN;
+          this.cd.detectChanges();
+          this.updateTasks();
+        }
+      });
+    }
+
+  }
+
+
+  public editStatus(listName: string, index: number): void {
+    const element = (listName === 'doneTasks' ? this.doneTasks : this.openTasks)[index];
+
+    this.getDialogSelection().subscribe({
+      next: result => {
+        switch (true) {
+          case !result:
+          case result === element.status:
+            return;
+          case result === Status.DONE:
+            this.moveElementToDone(index);
+            break;
+          case element.status === Status.DONE:
+            this.moveElementToOpen(index, result as Status);
+            break;
+          case result !== Status.DONE:
+            this.changeOpenElementStatus(index, result as Status);
+            break;
+        }
+      }
+    });
+  }
+
+  public isTaskDone(task: Task): boolean {
+    return task.status === Status.DONE;
+  }
+
+  public clearDoneTasks(): void {
+    this.doneTasks = [];
+    this.updateTasks();
+  }
+
+  private moveElementToDone(index: number): void {
+    const [elm] = this.openTasks.splice(index, 1);
+    this.doneTasks = [{...elm, status: Status.DONE}].concat(this.doneTasks);
+    this.cd.detectChanges();
+    this.updateTasks();
+  }
+
+  private moveElementToOpen(index: number, status: Status): void {
+    const [elm] = this.doneTasks.splice(index, 1);
+    this.openTasks = [{...elm, status}].concat(this.openTasks);
+    this.cd.detectChanges();
+    this.updateTasks();
+  }
+
+  private changeOpenElementStatus(index: number, status: Status): void {
+    this.openTasks[index].status = status;
+    this.cd.detectChanges();
+    this.updateTasks();
+  }
+
+  private drop(event: CdkDragDrop<Task[]>): void {
+    if (event.previousContainer === event.container) {
+      moveItemInArray(
+        event.container.data,
+        event.previousIndex,
+        event.currentIndex
+      );
+    } else {
+      transferArrayItem(
+        event.previousContainer.data,
+        event.container.data,
+        event.previousIndex,
+        event.currentIndex
+      );
+    }
+  }
+
+
+  private setTaskLists(tasks: Task[]): void {
+    this.doneTasks = [];
+    this.openTasks = [];
+    tasks.forEach(task => task.status === Status.DONE ? this.doneTasks.push(task) : this.openTasks.push(task));
+
+  }
+
+  private getDialogSelection(): Observable<Status | null> {
+    const dialogRef = this.dialog.open(TaskStatusDialogComponent, {width: '300px'});
+    return dialogRef.afterClosed().pipe(first());
+  }
+
+  private updateTasks(): void {
+    this.taskService.updateTasks(this.openTasks.concat(this.doneTasks)).pipe(first()).subscribe();
+  }
+
 }

--- a/src/main/webapp/app/tasks/task-status-dialog/task-status-dialog.component.html
+++ b/src/main/webapp/app/tasks/task-status-dialog/task-status-dialog.component.html
@@ -1,0 +1,13 @@
+<h4>Mark task as</h4>
+<mat-form-field appearance="fill">
+  <mat-label>New status</mat-label>
+  <mat-select [(value)]="selectedStatus" panelClass="matRole">
+    <mat-option *ngFor="let option of options" [value]="option">
+      {{option | titlecase}}
+    </mat-option>
+  </mat-select>
+</mat-form-field>
+<div class="button-container">
+  <button mat-raised-button (click)="choose()">Choose</button>
+</div>
+

--- a/src/main/webapp/app/tasks/task-status-dialog/task-status-dialog.component.scss
+++ b/src/main/webapp/app/tasks/task-status-dialog/task-status-dialog.component.scss
@@ -1,0 +1,12 @@
+.mat-form-field {
+  width: 100%;
+}
+
+.button-container {
+  float: right;
+
+  button {
+    background-color: #31BFCE;
+    color: white;
+  }
+}

--- a/src/main/webapp/app/tasks/task-status-dialog/task-status-dialog.component.spec.ts
+++ b/src/main/webapp/app/tasks/task-status-dialog/task-status-dialog.component.spec.ts
@@ -1,0 +1,40 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+
+import { TaskStatusDialogComponent } from './task-status-dialog.component';
+import { Status } from '../status';
+
+
+describe('TaskStatusDialogComponent', () => {
+  let component: TaskStatusDialogComponent;
+  let fixture: ComponentFixture<TaskStatusDialogComponent>;
+  let matDialogRefMock: jasmine.SpyObj<MatDialogRef<TaskStatusDialogComponent>>;
+
+  beforeEach(async () => {
+    matDialogRefMock = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    await TestBed.configureTestingModule({
+      declarations: [TaskStatusDialogComponent],
+      providers: [{provide: MatDialogRef, useValue: matDialogRefMock}],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    })
+      .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TaskStatusDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should call dialogRef close on choose method', () => {
+    component.selectedStatus = Status.OPEN;
+    component.choose();
+    expect(matDialogRefMock.close).toHaveBeenCalledWith(Status.OPEN);
+  })
+});

--- a/src/main/webapp/app/tasks/task-status-dialog/task-status-dialog.component.ts
+++ b/src/main/webapp/app/tasks/task-status-dialog/task-status-dialog.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { Status } from '../status';
+
+
+@Component({
+  selector: 'tiny-task-status-dialog',
+  templateUrl: './task-status-dialog.component.html',
+  styleUrls: ['./task-status-dialog.component.scss']
+})
+export class TaskStatusDialogComponent {
+  public options = Object.values(Status);
+  public selectedStatus = Status.OPEN;
+
+  constructor(public dialogRef: MatDialogRef<TaskStatusDialogComponent>) {
+  }
+
+  public choose(): void {
+    this.dialogRef.close(this.selectedStatus);
+  }
+}

--- a/src/main/webapp/app/tasks/task.service.ts
+++ b/src/main/webapp/app/tasks/task.service.ts
@@ -29,4 +29,12 @@ export interface TaskService {
    * @returns an empty `Observable`
    */
   delete(id: string): Observable<void>;
+
+  /**
+   * Updated the list of tasks.
+   *
+   * @param tasks the new list
+   * @returns the updated list
+   */
+  updateTasks(tasks: Task[]): Observable<Task[]>;
 }

--- a/src/main/webapp/app/tasks/task.ts
+++ b/src/main/webapp/app/tasks/task.ts
@@ -1,7 +1,10 @@
 /**
  * A tiny task.
  */
+import { Status } from './status';
+
 export interface Task {
   id: string;
   name: string;
+  status: Status;
 }

--- a/src/main/webapp/app/tasks/tasks.module.ts
+++ b/src/main/webapp/app/tasks/tasks.module.ts
@@ -5,19 +5,26 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatSelectModule } from '@angular/material/select';
 
 import { TaskFormComponent } from './task-form/task-form.component';
 import { TaskListComponent } from './task-list/task-list.component';
+import { TaskStatusDialogComponent } from './task-status-dialog/task-status-dialog.component';
 
 @NgModule({
-  declarations: [TaskFormComponent, TaskListComponent],
+  declarations: [TaskFormComponent, TaskListComponent, TaskStatusDialogComponent],
   imports: [
     CommonModule,
     ReactiveFormsModule,
     MatButtonModule,
     MatIconModule,
     MatInputModule,
-    MatListModule
+    MatListModule,
+    DragDropModule,
+    MatDialogModule,
+    MatSelectModule
   ],
   exports: [TaskFormComponent, TaskListComponent]
 })


### PR DESCRIPTION
A user can:
- view its tasks in 2 lists (open and done)
- drag tasks from one list to another changing the state
- change status of a task by clicking on the status text
- choose between different types of open statuses when moving a task to the open list (in progress, blocked, waiting)
- clear the done list
- sort tasks in each list